### PR TITLE
Update pocketsphinx.Args() slice length to fix #19.

### DIFF
--- a/pocketsphinx/util.go
+++ b/pocketsphinx/util.go
@@ -7,10 +7,30 @@ package pocketsphinx
 #include "cgo_helpers.h"
 */
 import "C"
+import (
+	"unsafe"
+)
 
 func Args() []Arg {
 	__ret := C.ps_args()
-	var __v = make([]Arg, 2048)
+	if __ret == nil {
+		return nil
+	}
+
+	// The array returned by ps_args() is terminated by CMDLN_EMPTY_OPTION.
+	// This matches the arg-counting logic in arg_strlen() in sphinxbase's
+	// src/libsphinxbase/util/cmd_ln.c.
+	var nargs uintptr
+	base := uintptr(unsafe.Pointer(__ret))
+	for {
+		arg := (*C.arg_t)(unsafe.Pointer(base + nargs*sizeOfArgValue))
+		if arg.name == nil {
+			break
+		}
+		nargs++
+	}
+
+	var __v = make([]Arg, nargs)
 	packSArg(__v, __ret)
 	return __v
 }


### PR DESCRIPTION
Make pocketsphinx.Args() iterate over the argument
definitions returned by ps_args() and pass a correctly-sized
slice to packSArg(). The previous behavior (passing a slice
of length 2048) would read past the end of the array,
causing segfaults.