### PR TITLE
Add FFT Option for decoder config

### DIFF
--- a/sphinx/config.go
+++ b/sphinx/config.go
@@ -74,6 +74,13 @@ func MFCLogDirOption(dir string) Option {
 	}
 }
 
+// FastFourierTransformOption
+func FastFourierTransformOption(points int) Option {
+	return func(c *Config) {
+		c.opt[String("-nfft")] = points
+	}
+}
+
 // RawLogDirOption sets directory to log raw audio files to.
 func RawLogDirOption(dir string) Option {
 	return func(c *Config) {


### PR DESCRIPTION
# Summary

- [x] Add function for Fast Fourier Transformation option in [`sphinx/config.go`](sphinx/config.go)



