### PR TITLE
Add keyphrase/keyword search

### DIFF
--- a/sphinx/sphinx.go
+++ b/sphinx/sphinx.go
@@ -322,3 +322,21 @@ func (d *Decoder) RawData() []int16 {
 	pocketsphinx.GetRawdata(d.dec, d.rawdataBuf, &size)
 	return d.rawdataBuf[0][:size]
 }
+
+// SetKeyphrase associates keyword search with the provided name. Activate
+// with Decoder.SetSearch()
+func (d *Decoder) SetKeyphrase(name string, keyphrase string) int32 {
+	return pocketsphinx.SetKeyphrase(d.dec, name, keyphrase)
+}
+
+// SetKws associates keyword search with the provided file. Activate
+// with Decoder.SetSearch()
+func (d *Decoder) SetKws(name string, keyfile string) int32 {
+	return pocketsphinx.SetKws(d.dec, name, keyfile)
+}
+
+// SetSearch activates the named search. The search must be set
+// beforehand with Decoder.SetKeyphrase() or Decoder.SetKws()
+func (d *Decoder) SetSearch(name string) int32 {
+	return pocketsphinx.SetSearch(d.dec, name)
+}


### PR DESCRIPTION
# Goal

Configure keyphrase/keyword search for decoder so consumers can swap between search types with `Decoder.SetSearch`

# Changes

Added the following to [sphinx.go](sphinx/sphinx.go):

- SetKeyphrase()
- SetKws()
- SetSearch()

Let me know if there's a better way to approach this. New to CMU PocketSphinx and attempting to implement keyphrase detection followed by grammar searching. [Relevant StackOverflow thread](https://stackoverflow.com/questions/39069614/pocketsphinx-how-to-switch-from-keyword-spotting-to-grammar-mode).